### PR TITLE
Upgrade to Express 4 + ECMA6

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,13 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = tab
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{json,yml,md,babelrc,eslintrc,remarkrc}]
+indent_style = space
+indent_size = 2

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,9 @@
+{
+  "extends": "tamia",
+  "parserOptions": {
+    "sourceType": "module"
+  },
+  "rules": {
+    "valid-jsdoc": 0
+  }
+}

--- a/oauth2.js
+++ b/oauth2.js
@@ -1,7 +1,7 @@
-var querystring= require('querystring'),
-    https= require('https'),
-    http= require('http'),
-    URL= require('url');
+const querystring= require('querystring');
+const https= require('https');
+const http= require('http');    
+const URL= require('url');
 
 exports.OAuth2= function(clientId, clientSecret, baseSite, authorizePath, accessTokenPath, callbackURL, customHeaders) {
   this._clientId= clientId;
@@ -31,79 +31,79 @@ exports.OAuth2.prototype._getAccessTokenUrl= function() {
 // Build the authorization header. In particular, build the part after the colon.
 // e.g. Authorization: Bearer <token>  # Build "Bearer <token>"
 exports.OAuth2.prototype.buildAuthHeader= function() {
-  var key = this._clientId + ':' + this._clientSecret;
-  var base64 = (new Buffer(key)).toString('base64');
+  const key = this._clientId + ':' + this._clientSecret;
+  const base64 = (new Buffer(key)).toString('base64');
   return this._authMethod + ' ' + base64;
 };
 
-exports.OAuth2.prototype._request= function(method, url, headers, post_body, access_token, callback) {
+exports.OAuth2.prototype._request= function(method, url, headers, postBody, accessToken, callback) {
 
-  var http_library= https;
-  var parsedUrl= URL.parse( url, true );
-  if( parsedUrl.protocol == "https:" && !parsedUrl.port ) {
+  let httpLibrary= https;
+  const parsedUrl= URL.parse( url, true );
+  if( parsedUrl.protocol === "https:" && !parsedUrl.port ) {
     parsedUrl.port= 443;
   }
 
   // As this is OAUth2, we *assume* https unless told explicitly otherwise.
-  if( parsedUrl.protocol != "https:" ) {
-    http_library= http;
+  if( parsedUrl.protocol !== "https:" ) {
+    httpLibrary= http;
   }
 
-  var realHeaders= {};
-  for( var key in this._customHeaders ) {
+  const realHeaders= {};
+  for( const key in this._customHeaders ) {
     realHeaders[key]= this._customHeaders[key];
   }
   if( headers ) {
-    for(var key in headers) {
+    for(const key in headers) {
       realHeaders[key] = headers[key];
     }
   }
-  realHeaders['Host']= parsedUrl.host;
+  realHeaders.Host= parsedUrl.host;
 
-  //realHeaders['Content-Length']= post_body ? Buffer.byteLength(post_body) : 0;
-  if( access_token && !('Authorization' in realHeaders)) {
-    if( ! parsedUrl.query ) parsedUrl.query= {};
-    parsedUrl.query[this._accessTokenName]= access_token;
+  //realHeaders['Content-Length']= postBody ? Buffer.byteLength(postBody) : 0;
+  if( accessToken && !('Authorization' in realHeaders)) {
+    if( ! parsedUrl.query ) {parsedUrl.query= {};}
+    parsedUrl.query[this._accessTokenName]= accessToken;
   }
 
-  var queryStr= querystring.stringify(parsedUrl.query);
-  if( queryStr ) queryStr=  "?" + queryStr;
-  var options = {
+  let queryStr= querystring.stringify(parsedUrl.query);
+  if( queryStr ) {queryStr=  "?" + queryStr;}
+  const options = {
     host:parsedUrl.hostname,
     port: parsedUrl.port,
     path: parsedUrl.pathname + queryStr,
-    method: method,
+    method,
     headers: realHeaders
   };
 
-  this._executeRequest( http_library, options, post_body, callback );
+  this._executeRequest( httpLibrary, options, postBody, callback );
 }
 
-exports.OAuth2.prototype._executeRequest= function( http_library, options, post_body, callback ) {
+exports.OAuth2.prototype._executeRequest= function( httpLibrary, options, postBody, callback ) {
   // Some hosts *cough* google appear to close the connection early / send no content-length header
   // allow this behaviour.
-  var allowEarlyClose= options.host && options.host.match(".*google(apis)?.com$");
-  var callbackCalled= false;
-  function passBackControl( response, result ) {
+  const allowEarlyClose= options.host && options.host.match(".*google(apis)?.com$");
+  let callbackCalled= false;
+  function passBackControl( response, result, err ) {
     if(!callbackCalled) {
       callbackCalled=true;
-      if( response.statusCode != 200 && (response.statusCode != 301) && (response.statusCode != 302) ) {
+      if( response.statusCode !== 200 && response.statusCode !== 201 &&  (response.statusCode !== 301) && (response.statusCode !== 302) ) {
         callback({ statusCode: response.statusCode, data: result });
       } else {
-        callback(null, result, response);
+        callback(err, result, response);
       }
     }
   }
 
-  var result= "";
+  let result= "";
 
-  var request = http_library.request(options, function (response) {
+  const request = httpLibrary.request(options, function (response) {
     response.on("data", function (chunk) {
       result+= chunk
     });
     response.on("close", function (err) {
       if( allowEarlyClose ) {
-        passBackControl( response, result );
+        passBackControl( response, result, err );
       }
     });
     response.addListener("end", function () {
@@ -115,51 +115,88 @@ exports.OAuth2.prototype._executeRequest= function( http_library, options, post_
     callback(e);
   });
 
-  if(options.method == 'POST' && post_body) {
-     request.write(post_body);
+  if(options.method === 'POST' && postBody) {
+     request.write(postBody);
   }
   request.end();  
 }
 
-exports.OAuth2.prototype.getAuthorizeUrl= function(response_type) {
+exports.OAuth2.prototype.getAuthorizeUrl= function(responseType) {
   
-  response_type = response_type || 'code';
+  responseType = responseType || 'code';
 
-  return this._baseSite + this._authorizeUrl + '?response_type=' + response_type + '&client_id=' + this._clientId +  '&state=xyz&redirect_uri=' + this._callbackURL;
+  return this._baseSite + this._authorizeUrl + '?response_type=' + responseType + '&client_id=' + this._clientId +  '&state=xyz&redirect_uri=' + this._callbackURL;
 
 }
 
-exports.OAuth2.prototype.getOAuthAccessToken= function(code, callback) {
+function getResults(data){
+  let results;
+  try {
+    results= JSON.parse(data);
+  }
+  catch(e) {
+    results= querystring.parse(data);
+  }
+  return results;
+}
 
-  var post_data = 'grant_type=authorization_code&code=' + code + '&redirect_uri=' + this._callbackURL;
+exports.OAuth2.prototype.getOAuthAccessToken= function(code) {
+  const that = this;
 
-  var post_headers= {
-       'Authorization': this.buildAuthHeader(),
-       'Content-Type': 'application/x-www-form-urlencoded',
-       'Content-Length': post_data.length,
-   };
+  return new Promise((resolve, reject) => { 
+    const postData = 'grant_type=authorization_code&code=' + code + '&redirect_uri=' + that._callbackURL;
 
-  this._request("POST", this._getAccessTokenUrl(), post_headers, post_data, null, function(error, data, response) {
-    if( error )  callback(error);
-    else {
-      var results;
-      try {
-        // As of http://tools.ietf.org/html/draft-ietf-oauth-v2-07
-        // responses should be in JSON
-        results= JSON.parse(data);
-      }
-      catch(e) {
-        // .... However both Facebook + Github currently use rev05 of the spec
-        // and neither seem to specify a content-type correctly in their response headers :(
-        // clients of these services will suffer a *minor* performance cost of the exception
-        // being thrown
-        results= querystring.parse(data);
-      }
-      callback(null, results);
-    }
+    const postHeaders= {
+         'Authorization': that.buildAuthHeader(),
+         'Content-Type': 'application/x-www-form-urlencoded',
+         'Content-Length': postData.length,
+     };
+
+    that._request("POST", that._getAccessTokenUrl(), postHeaders, postData, null, (error, data) => {
+      return error ? reject(error) : resolve(getResults(data));
+    });
   });
 }
 
-exports.OAuth2.prototype.get= function(url, access_token, callback) {
-  this._request("GET", url, {}, "", access_token, callback);
+
+exports.OAuth2.prototype.getOAuthClientCredentials= function() {
+  const that = this;
+  return new Promise((resolve, reject) => {
+    const postData = 'grant_type=client_credentials';
+    const postHeaders= {
+         'Authorization': that.buildAuthHeader(),
+         'Content-Type': 'application/x-www-form-urlencoded',
+         'Content-Length': postData.length,
+     };
+
+    that._request("POST", that._getAccessTokenUrl(), postHeaders, postData, null, (error, data) => {
+      return error ? reject(error) : resolve(getResults(data));
+    });
+  });
+}
+
+
+exports.OAuth2.prototype.getOAuthPasswordCredentials= function(username, password) {
+  const that = this;
+  return new Promise((resolve, reject) => {
+    const postData = 'grant_type=password&username=' + username + '&password=' + password;
+    const postHeaders= {
+         'Authorization': that.buildAuthHeader(),
+         'Content-Type': 'application/x-www-form-urlencoded',
+         'Content-Length': postData.length,
+     };
+
+    that._request("POST", that._getAccessTokenUrl(), postHeaders, postData, null, (error, data) => {
+      return error ? reject(error) : resolve(getResults(data));
+    });
+  });
+}
+
+exports.OAuth2.prototype.get= function(url, accessToken) {
+  const that = this;
+  return new Promise((resolve, reject) => {
+    that._request("GET", url, {}, "", accessToken, (error, data) => {
+      return error ? reject(error) : resolve(data);
+    });
+  });
 }

--- a/package.json
+++ b/package.json
@@ -3,8 +3,27 @@
   "version": "0.1.0",
   "description": "Oauth2 authentication example for FI-WARE GE applications",
   "author": "GING DIT UPM",
+  "scripts": {
+    "start": "node server.js",
+    "lint": "eslint . --cache --fix"
+  },
+  "engines": {
+    "node": ">=8.6"
+  },
   "dependencies": {
-    "express": "3.x"
+    "express": "~4.16.0",
+    "morgan": "~1.9.0",
+    "body-parser": "^1.18.3",
+    "cookie-parser": "~1.4.3",
+    "express-session": "^1.15.6"
+  },
+  "devDependencies": {
+    "ajv": "^6.5.2",
+    "eslint": "^5.3.0",
+    "eslint-config-tamia": "^6.0.1",
+    "eslint-plugin-prettier": "^2.6.2",
+    "memfs": "2.9.4",
+    "prettier": "^1.14.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR modernizes the existing codebase to use current nodejs programming techniques.

* Express 3.0 has been superceded - Update dependencies to use Express 4
* ECMA6 is fully supported on nodejs server apps - switch from var to const/let
* Promises are now fully supported and preferred over callback - callbacks have been replaced with Promises
* Add OAuth2 endpoints for all common grant types (Password, Implicit, Client and Authcode)
* Code has been auto-formatted using Prettier.